### PR TITLE
Bump request dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/main.js",
   "name": "mksnapshot",
   "description": "Create snapshot file for Electron",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "licenses": [
     {
       "type": "MIT",
@@ -30,6 +30,6 @@
   "dependencies": {
     "decompress-zip": "0.3.0",
     "fs-extra": "0.26.7",
-    "request": "^2.72.0"
+    "request": "^2.79.0"
   }
 }


### PR DESCRIPTION
Bumps request dep to latest, to avoid deprecated `node-uuid` package.